### PR TITLE
Declare size variable

### DIFF
--- a/include/fplib/FloatingAverage.h
+++ b/include/fplib/FloatingAverage.h
@@ -82,6 +82,7 @@ public:
    {
       T real_sum = 0;
       const T* pCircularBuffer = m_values.get_buffer();
+      const int size = m_values.size();
       for ( int i = 0; i < size; ++i )
          real_sum += pCircularBuffer[i];
       return abs(real_sum - m_sum) / this->size();


### PR DESCRIPTION
For clang this code fails to compile, and it's not hard to see why. Frankly it is amazing it compiled with GCC and CL! What I think happened is the address of the size function from the class was used. You may want to look into that, perhaps this code is never called?
