### PR TITLE
Fixed linkage of libsamplerate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,10 @@ SET_TARGET_PROPERTIES(fplib_shared
    PROPERTIES OUTPUT_NAME fplib
    )
 
+TARGET_LINK_LIBRARIES(fplib_shared
+	samplerate
+	)
+
 # Install static library
 INSTALL(TARGETS fplib_static
    ARCHIVE DESTINATION lib


### PR DESCRIPTION
On my system (Ubuntu 13.10, gcc 4.8.1-10ubuntu8), linking of lastfm-fpclient fails on the libsamplerate symbols used in libfplib.
adding `-lsamplerate` to the linking step of fplip_shared fixed this.
